### PR TITLE
tests: fix numerical precision problems

### DIFF
--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -10,6 +10,7 @@ class TestDynamics(unittest.TestCase):
         from samos.utils.constants import bohr_to_ang
         from samos.plotting.plot_dynamics import plot_msd_isotropic, plot_vaf_isotropic, plot_power_spectrum
         import json
+        import numpy as np
         t = Trajectory.load_file('data/H2O-64-300K.tar.gz')
         t.recenter()
         t.rescale_array(t._VELOCITIES_KEY, bohr_to_ang)
@@ -42,7 +43,7 @@ class TestDynamics(unittest.TestCase):
                 #~ json.dump(attrs , f)
             with open('ref/{}_H2O-64-300K.json'.format(name), 'r') as f:
                 ref_attrs = json.load(f)
-            self.assertEqual(ref_attrs, attrs)
+            self.assertAlmostEqual(ref_attrs, attrs, places=12)
 
 
         # Uncomment to test plot:

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -18,15 +18,15 @@ class TestTrajectory(unittest.TestCase):
         t.set_velocities(vel)
         t.set_forces(frc)
 
-        self.assertTrue(np.array_equal(pos, t.get_positions()))
-        self.assertTrue(np.array_equal(vel, t.get_velocities()))
-        self.assertTrue(np.array_equal(frc, t.get_forces()))
+        np.testing.assert_almost_equal(pos, t.get_positions(), decimal=12)
+        np.testing.assert_almost_equal(vel, t.get_velocities(), decimal=12)
+        np.testing.assert_almost_equal(frc, t.get_forces(), decimal=12)
 
 
         atoms_step_3 = t.get_step_atoms(3)
 
-        self.assertTrue(np.array_equal(atoms_step_3.get_positions(), pos[3]))
-        self.assertTrue(np.array_equal(atoms_step_3.get_velocities(), vel[3]))
+        np.testing.assert_almost_equal(atoms_step_3.get_positions(), pos[3], decimal=12)
+        np.testing.assert_almost_equal(atoms_step_3.get_velocities(), vel[3], decimal=12)
 
 
     def test_store_and_reload(self):
@@ -48,10 +48,10 @@ class TestTrajectory(unittest.TestCase):
             t.save(f.name)
             tnew =  Trajectory.load_file(f.name)
 
-        self.assertTrue(np.array_equal(pos, tnew.get_positions()))
-        self.assertTrue(np.array_equal(vel, tnew.get_velocities()))
-        self.assertTrue(np.array_equal(frc, tnew.get_forces()))
-        self.assertTrue(np.array_equal(xtr, tnew.get_array('extra')))
+        np.testing.assert_almost_equal(pos, tnew.get_positions(), decimal=12)
+        np.testing.assert_almost_equal(vel, tnew.get_velocities(), decimal=12)
+        np.testing.assert_almost_equal(frc, tnew.get_forces(), decimal=12)
+        np.testing.assert_almost_equal(xtr, tnew.get_array('extra'), decimal=12)
 
     def test_compatibility(self):
         from samos.trajectory import Trajectory, check_trajectory_compatibility, IncompatibleTrajectoriesException


### PR DESCRIPTION
Due to numerical precision, sometimes the assertEqual method failed
due to small differences (of the order of 1e-16) in float values.
Now it has been fixed using almost-equal asserts.